### PR TITLE
Authentication Updates

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -16,6 +16,7 @@ export async function middleware(req) {
       pathname.startsWith("/api") || //  exclude all API routes
       pathname.startsWith("/static") || // exclude static files
       pathname.includes(".") || // exclude all files in the public folder
+      pathname.includes("aboutus") ||
       PUBLIC_FILE.test(pathname) || token
     
     


### PR DESCRIPTION
- Nextjs had a deprecated practice in terms of middleware naming convention and corresponding pathnames allowed
- Fixed the above issue by moving and renaming Middleware.js and changing the allowed pathnames